### PR TITLE
Remove support for running goreleaser with --snapshot

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist ${{ startsWith(github.ref, 'refs/tags/') && '' || '--snapshot' }}
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Empty string seems to be falsy, resulting in `--snapshot` still being set for actual releases. Since the workflow only runs on tags there's no need to support snapshots at the moment.