### PR TITLE
Fix metrics reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Unique Jobs are supported and follow the [official implementation](https://githu
 #### Configuration (required)
 
 Uniq settings are under the `[uniq]` configuration:
+
 ```
 [uniq]
 enabled = true # enables this plugin
@@ -21,9 +22,9 @@ enabled = true # enables this plugin
 Metrics are collected through a task and middleware.
 
 Metrics tracked through middleware are:
-`jobs.succeeded.count` - number of jobs successful
+`jobs.succeeded.time.count` - number of jobs successful
 `jobs.succeeded.time` - time to complete
-`jobs.failed.count` - number of jobs failed
+`jobs.failed.time.count` - number of jobs failed
 `jobs.failed.time` - time to complete
 
 Metrics tracked through a task (every 10 seconds) are:
@@ -39,6 +40,7 @@ Metrics tracked through a task (every 10 seconds) are:
 #### Configuration (required)
 
 Any file ending in .toml will be read as a configuration file for faktory. Here's an example:
+
 ```
 [metrics]
 enabled = true # enables this plugin
@@ -48,7 +50,7 @@ tags = ["tag1:value1", "tag2:value2"] # tags passed to datadog on every metric
 
 Tags can also be set the with env variable `DD_TAGS="tagName:value,tagName:value"
 
-specify the host with `DD_AGENT_HOST`
+The address of the statsd server should be set in the `DD_AGENT_HOST` environment variable.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,17 @@ go 1.17
 
 require github.com/contribsys/faktory v1.5.5
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/DataDog/datadog-go v4.8.2+incompatible
+	github.com/golang/mock v1.6.0
+	github.com/stretchr/testify v1.7.0
+)
 
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	github.com/DataDog/datadog-go v4.8.2+incompatible // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-redis/redis v6.15.7+incompatible // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/justinas/nosurf v1.1.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -107,23 +107,20 @@ func TestMetrics(t *testing.T) {
 
 			// middleware jobs
 			tags := []string{"tag1:value1", "tag2:value2"}
-			mockDoer.EXPECT().Incr("jobs.succeeded.count", gomock.Any(), gomock.Any()).Return(nil).Times(3)
 			mockDoer.EXPECT().Timing("jobs.succeeded.time", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
-			// one of the failed jobs has a retry value > 0
-			mockDoer.EXPECT().Incr("jobs.failed.count", gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			mockDoer.EXPECT().Timing("jobs.failed.time", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 
 			// task calls
-			mockDoer.EXPECT().Count("jobs.working.count", int64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.scheduled.count", int64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.retries.count", int64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.dead.count", int64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.enqueued.count", int64(8), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.enqueued.default.count", int64(1), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.working.count", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.scheduled.count", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.retries.count", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.dead.count", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.enqueued.count", float64(8), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.enqueued.default.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.default.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.enqueued.builds.count", int64(6), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.count", float64(6), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Count("jobs.enqueued.tests.count", int64(1), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 
 			// create 15 jobs

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -17,10 +17,6 @@ func (m *MetricsSubsystem) addMiddleware() {
 			}
 		}
 
-		if err := m.StatsDClient().Incr(m.PrefixMetricName("succeeded.count"), tags, 1); err != nil {
-			util.Warnf("unable to submit metric: %v", err)
-		}
-
 		return next()
 	})
 	m.Server.Manager().AddMiddleware("fail", func(next func() error, ctx manager.Context) error {
@@ -28,13 +24,6 @@ func (m *MetricsSubsystem) addMiddleware() {
 
 		if ctx.Reservation() != nil {
 			m.StatsDClient().Timing(m.PrefixMetricName("failed.time"), time.Duration(time.Now().Sub(ctx.Reservation().ReservedAt())), tags, 1)
-		}
-
-		if ctx.Job().Failure.RetryCount >= ctx.Job().Retry {
-			// only count a job as failed on the last retry
-			if err := m.StatsDClient().Incr(m.PrefixMetricName("failed.count"), tags, 1); err != nil {
-				util.Warnf("unable to submit metric: %v", err)
-			}
 		}
 		return next()
 	})

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -72,12 +72,13 @@ func (m *metricsTask) Execute() error {
 			}
 			return nil
 		})
-
+		util.Debugf("metrics: enqueued.%s.count: %d", queue.Name(), count)
 	})
 
 	if err := m.Subsystem.StatsDClient().Count(m.Subsystem.PrefixMetricName("enqueued.count"), int64(totalEnqueued), m.Subsystem.Options.Tags, 1); err != nil {
 		util.Warnf("unable to submit metric: %v", err)
 	}
+	util.Debugf("metrics: enqueued.count: %d", totalEnqueued)
 
 	return nil
 }


### PR DESCRIPTION
When reporting the state of the various queues and working sets, we were originally using count metrics. Unfortunately, this meant that they would be reset to 0 every time statsd flushed. These have been changed to gauge metrics which do not have this behaviour. See [here](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#counting).

I've also removed the two count metrics from the middleware routes, since those are covered by the timing metrics.