### PR TITLE
Refactor batching locks

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -487,7 +487,7 @@ func (m *batchManager) areBatchJobsSucceeded(batch *batch) bool {
 func (m *batchManager) handleBatchJobsCompleted(batch *batch, parentsVisited map[string]bool) {
 	areChildrenFinished, areChildrenSucceeded := m.areChildrenFinished(batch)
 	if areChildrenFinished {
-		util.Infof("batch: %s children are finished", batch.Id)
+		util.Debugf("batch: %s children are finished", batch.Id)
 		m.handleBatchCompleted(batch, areChildrenSucceeded)
 	}
 	// notify parents child is done

--- a/batch/child_test.go
+++ b/batch/child_test.go
@@ -72,6 +72,9 @@ func TestChildBatch(t *testing.T) {
 					assert.Nil(t, err)
 					assert.Equal(t, val, "OK")
 
+					val, err = cl.Generic(fmt.Sprintf("BATCH CHILD %s %s", batchA1.Bid, batch.Bid))
+					assert.Nil(t, err)
+					assert.Equal(t, val, "OK")
 					return nil
 				})
 				assert.Nil(t, err)

--- a/batch/middlware.go
+++ b/batch/middlware.go
@@ -19,7 +19,7 @@ func (b *BatchSubsystem) pushMiddleware(next func() error, ctx manager.Context) 
 			util.Warnf("unable to add batch %v", err)
 			return fmt.Errorf("pushMiddleware: Unable to add job %s to batch %s", ctx.Job().Jid, bid)
 		}
-		util.Infof("Added %s to batch %s", ctx.Job().Jid, batch.Id)
+		util.Debugf("Added %s to batch %s", ctx.Job().Jid, batch.Id)
 	}
 	return next()
 }
@@ -63,7 +63,7 @@ func (b *BatchSubsystem) handleJobFinished(success bool) func(next func() error,
 			if !success {
 				status = "failed"
 			}
-			util.Infof("Job(%s) %s for batch %s", ctx.Job().Jid, status, batch.Id)
+			util.Debugf("Job(%s) %s for batch %s", ctx.Job().Jid, status, batch.Id)
 
 			isRetry := ctx.Job().Failure != nil && ctx.Job().Failure.RetryCount > 0
 

--- a/batch/middlware.go
+++ b/batch/middlware.go
@@ -13,7 +13,9 @@ func (b *BatchSubsystem) pushMiddleware(next func() error, ctx manager.Context) 
 		if err != nil {
 			return fmt.Errorf("pushMiddleware: unable to get batch %s", bid)
 		}
-		if err := b.batchManager.handleJobQueued(batch, ctx.Job().Jid); err != nil {
+		batch.mu.Lock()
+		defer batch.mu.Unlock()
+		if err := b.batchManager.handleJobQueued(batch); err != nil {
 			util.Warnf("unable to add batch %v", err)
 			return fmt.Errorf("pushMiddleware: Unable to add job %s to batch %s", ctx.Job().Jid, bid)
 		}
@@ -32,6 +34,8 @@ func (b *BatchSubsystem) handleJobFinished(success bool) func(next func() error,
 					util.Warnf("Unable to retrieve batch %s: %v", bid, err)
 					return next()
 				}
+				batch.mu.Lock()
+				defer batch.mu.Unlock()
 				cb, ok := ctx.Job().GetCustom("_cb")
 				if !ok {
 					util.Warnf("Batch (%s) callback job (%s) does not have _cb specified", bid, ctx.Job().Type)
@@ -53,7 +57,8 @@ func (b *BatchSubsystem) handleJobFinished(success bool) func(next func() error,
 			if err != nil {
 				return fmt.Errorf("handleJobFinished: unable to retrieve batch %s", bid)
 			}
-
+			batch.mu.Lock()
+			defer batch.mu.Unlock()
 			status := "succeeded"
 			if !success {
 				status = "failed"

--- a/batch/subsystem.go
+++ b/batch/subsystem.go
@@ -37,7 +37,7 @@ func (b *BatchSubsystem) Start(s *server.Server) error {
 	b.Server = s
 	b.batchManager = &batchManager{
 		Batches:   make(map[string]*batch),
-		mu:        sync.Mutex{},
+		mu:        sync.RWMutex{},
 		rclient:   b.Server.Manager().Redis(),
 		Subsystem: b,
 	}


### PR DESCRIPTION
This PR refactors the batching mutex locks, any command / middleware function that mutates a batches state will hold a lock until the state is updated. This makes processing batches a bit slower, but will avoid any issues concurrent updates to batches.
