### PR TITLE
Fix deadlock in remove stale batches

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -154,19 +154,17 @@ func (m *batchManager) removeBatch(batch *batch) {
 }
 
 func (m *batchManager) removeStaleBatches() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	for _, b := range m.Batches {
 		createdAt, err := time.Parse(time.RFC3339Nano, b.Meta.CreatedAt)
 		if err != nil {
 			continue
 		}
 		remove := false
-		uncomittedTimeout := time.Now().Add(-time.Duration(m.Subsystem.Options.UncommittedTimeoutMinutes) * time.Minute)
-		comittedTimeout := time.Now().AddDate(0, 0, -m.Subsystem.Options.CommittedTimeoutDays)
-		if !b.Meta.Committed && createdAt.Before(uncomittedTimeout) {
+		uncommittedTimeout := time.Now().UTC().Add(-time.Duration(m.Subsystem.Options.UncommittedTimeoutMinutes) * time.Minute)
+		committedTimeout := time.Now().UTC().AddDate(0, 0, -m.Subsystem.Options.CommittedTimeoutDays)
+		if !b.Meta.Committed && createdAt.Before(uncommittedTimeout) {
 			remove = true
-		} else if b.Meta.Committed && createdAt.Before(comittedTimeout) {
+		} else if b.Meta.Committed && createdAt.Before(committedTimeout) {
 			remove = true
 		}
 

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -154,14 +154,15 @@ func (m *batchManager) removeBatch(batch *batch) {
 }
 
 func (m *batchManager) removeStaleBatches() {
+	util.Debugf("Checking for stale batches")
 	for _, b := range m.Batches {
 		createdAt, err := time.Parse(time.RFC3339Nano, b.Meta.CreatedAt)
 		if err != nil {
 			continue
 		}
 		remove := false
-		uncommittedTimeout := time.Now().UTC().Add(-time.Duration(m.Subsystem.Options.UncommittedTimeoutMinutes) * time.Minute)
-		committedTimeout := time.Now().UTC().AddDate(0, 0, -m.Subsystem.Options.CommittedTimeoutDays)
+		uncommittedTimeout := time.Now().Add(-time.Duration(m.Subsystem.Options.UncommittedTimeoutMinutes) * time.Minute).UTC()
+		committedTimeout := time.Now().AddDate(0, 0, -m.Subsystem.Options.CommittedTimeoutDays).UTC()
 		if !b.Meta.Committed && createdAt.Before(uncommittedTimeout) {
 			remove = true
 		} else if b.Meta.Committed && createdAt.Before(committedTimeout) {

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -388,7 +388,6 @@ func TestRemoveStaleBatches(t *testing.T) {
 		committedBatchId := fmt.Sprintf("b-%s", util.RandomJid())
 		meta := batchSystem.batchManager.newBatchMeta("testing", "", "", nil)
 		meta.CreatedAt = time.Now().UTC().Add(-time.Duration(1)*time.Minute).AddDate(0, 0, -batchSystem.Options.CommittedTimeoutDays).Format(time.RFC3339Nano)
-		fmt.Println(meta.CreatedAt)
 		batch, err := batchSystem.batchManager.newBatch(committedBatchId, meta)
 		assert.Nil(t, err)
 		err = batchSystem.batchManager.commit(batch)

--- a/batch/subsystem.go
+++ b/batch/subsystem.go
@@ -70,28 +70,28 @@ func (b *BatchSubsystem) getOptions(s *server.Server) *Options {
 		enabled = false
 	}
 	childSearchDepthValue := s.Options.Config("batch", "child_search_depth", 0)
-	childSearchDepth, ok := childSearchDepthValue.(int)
+	childSearchDepth, ok := childSearchDepthValue.(int64)
 	if !ok {
 		childSearchDepth = 0
 	}
 
 	uncommittedTimeoutValue := s.Options.Config("batch", "uncommitted_timeout_minutes", 120)
-	uncommittedTimeout, ok := uncommittedTimeoutValue.(int)
+	uncommittedTimeout, ok := uncommittedTimeoutValue.(int64)
 	if !ok {
 		uncommittedTimeout = 120
 	}
 
 	committedTimeoutValue := s.Options.Config("batch", "committed_timeout_days", 7)
-	committedTimeout, ok := committedTimeoutValue.(int)
+	committedTimeout, ok := committedTimeoutValue.(int64)
 	if !ok {
 		committedTimeout = 7
 	}
 
 	return &Options{
 		Enabled:                   enabled,
-		ChildSearchDepth:          childSearchDepth,
-		UncommittedTimeoutMinutes: uncommittedTimeout,
-		CommittedTimeoutDays:      committedTimeout,
+		ChildSearchDepth:          int(childSearchDepth),
+		UncommittedTimeoutMinutes: int(uncommittedTimeout),
+		CommittedTimeoutDays:      int(committedTimeout),
 	}
 }
 


### PR DESCRIPTION
- removeStaleBatches was creating a deadlock when trying to delete any batches as removing uses the same lock
this PR:
- fixes the issue and adds a test case
- fixes a spelling mistake
- ensures UTC comparison as that is what createdAt is