### PR TITLE
[No Ticket] Bugfix: Prevent leaving the batch open when there's an error setting the child batch

### DIFF
--- a/batch/commands.go
+++ b/batch/commands.go
@@ -150,9 +150,7 @@ func (b *BatchSubsystem) batchCommand(c *server.Connection, s *server.Server, cm
 		childBatch, err := b.batchManager.getBatch(childBatchId)
 		if err != nil {
 			_ = c.Error(cmd, fmt.Errorf("cannot get child batch: %v", err))
-			return
-		}
-		if err := b.batchManager.addChild(batch, childBatch); err != nil {
+		} else if err := b.batchManager.addChild(batch, childBatch); err != nil {
 			_ = c.Error(cmd, fmt.Errorf("cannot add child (%s) to batch (%s): %v", childBatchId, batchId, err))
 		}
 		if opened {


### PR DESCRIPTION
In order to set the child batch, the parent batch needs to be open (`committed = false`) if is not already. Once the association is done, if the batch was previously committed, it should be committed again.
If there was an error retrieving the child batch, the parent batch always remained open.
This PR addresses this bug.