### PR TITLE
Send connection count metrics to StatsD

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -111,6 +111,7 @@ func TestMetrics(t *testing.T) {
 			mockDoer.EXPECT().Timing("jobs.failed.time", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 
 			// task calls
+			mockDoer.EXPECT().Gauge("jobs.connections.count", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.working.count", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.scheduled.count", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.retries.count", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -24,6 +24,11 @@ func (m *metricsTask) Name() string {
 
 // Execute - runs the task to collect metrics
 func (m *metricsTask) Execute() error {
+	connectionCount := m.Subsystem.Server.Stats.Connections
+	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("connections.count"), float64(connectionCount), m.Subsystem.Options.Tags, 1); err != nil {
+		util.Warnf("unable to submit metric: %v", err)
+	}
+	
 	workingCount := m.Subsystem.Server.Store().Working().Size()
 	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("working.count"), float64(workingCount), m.Subsystem.Options.Tags, 1); err != nil {
 		util.Warnf("unable to submit metric: %v", err)


### PR DESCRIPTION
Faktory sets the `PoolSize` for its connection to Redis to 1000. This value is currently hard-coded.

From the [Faktory src](https://github.com/contribsys/faktory/blob/7a196fc2b9ca85848db6a855d0dc0a07fba14f0e/server/server.go#L136-L138)
> 		// Each connection gets its own goroutine which ultimately limits Faktory's scalability.
>		// Faktory hardcodes a limit of `DefaultMaxPoolSize` Redis connections but does not put a limit here
>		// because Go's runtime scheduler will get better over time.

We want to be able to track the number of connections to Faktory so that we can be prepared for any issues this might cause.