### PR TITLE
run task in separate go routine

### DIFF
--- a/batch/task.go
+++ b/batch/task.go
@@ -17,7 +17,7 @@ func (t *removeStaleBatches) Name() string {
 
 // Execute - runs the task to collect metrics
 func (t *removeStaleBatches) Execute() error {
-	t.Subsystem.batchManager.removeStaleBatches()
+	go t.Subsystem.batchManager.removeStaleBatches()
 	return nil
 }
 


### PR DESCRIPTION
faktory runs all tasks in the same go routine - if a task freezes or takes forever other tasks wont run until it finishes. This PR makes it so removeStaleBatches runs in a separate routine which will not affect other tasks