### PR TITLE
Set batch total to "0" in case it is an empty string

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -287,7 +287,13 @@ func (m *batchManager) init(batch *batch) error {
 		return nil
 	}
 
-	batch.Meta.Total, err = strconv.Atoi(meta["total"])
+	var batchTotal string
+	if len(meta["total"]) > 0 {
+		batchTotal = meta["total"]
+	} else {
+		batchTotal = "0"
+	}
+	batch.Meta.Total, err = strconv.Atoi(batchTotal)
 	if err != nil {
 		return fmt.Errorf("init: total: failed converting string to int: %v", err)
 	}


### PR DESCRIPTION
When loading a batch, `total` could be unset and so `strconv.Atoi(total)` throws an error.
A check was added to set `total = "0"` in case it is an empty string.