### PR TITLE
fixes to batching

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -160,7 +160,6 @@ func (m *batchManager) getBatch(batchId string) (*batch, error) {
 	exists, err := m.rclient.Exists(m.getBatchKey(b.Id)).Result()
 	if err != nil {
 		util.Warnf("Cannot confirm batch exists: %v", err)
-		m.mu.Unlock()
 		return nil, fmt.Errorf("getBatch: unable to check if batch has timed out")
 	}
 	if exists == 0 {

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -147,7 +147,7 @@ func (m *batchManager) getBatch(batchId string) (*batch, error) {
 	}
 	if exists == 0 {
 		m.removeBatch(b)
-		return nil, fmt.Errorf("getBatch: batch was not committed within 2 hours")
+		return nil, fmt.Errorf("getBatch: batch has timed out")
 	}
 
 	return b, nil

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -165,18 +165,21 @@ func (m *batchManager) removeBatch(batch *batch) {
 }
 
 func (m *batchManager) removeStaleBatches() {
-	util.Debugf("Checking for stale batches")
 	for _, b := range m.Batches {
-		createdAt, err := time.Parse(time.RFC3339Nano, b.Meta.CreatedAt)
-		if err != nil {
-			continue
-		}
 		remove := false
-		uncommittedTimeout := time.Now().Add(-time.Duration(m.Subsystem.Options.UncommittedTimeoutMinutes) * time.Minute).UTC()
-		committedTimeout := time.Now().AddDate(0, 0, -m.Subsystem.Options.CommittedTimeoutDays).UTC()
-		if !b.Meta.Committed && createdAt.Before(uncommittedTimeout) {
-			remove = true
-		} else if b.Meta.Committed && createdAt.Before(committedTimeout) {
+		if b.Meta.CreatedAt != "" {
+			createdAt, err := time.Parse(time.RFC3339Nano, b.Meta.CreatedAt)
+			if err != nil {
+				continue
+			}
+			uncommittedTimeout := time.Now().Add(-time.Duration(m.Subsystem.Options.UncommittedTimeoutMinutes) * time.Minute).UTC()
+			committedTimeout := time.Now().AddDate(0, 0, -m.Subsystem.Options.CommittedTimeoutDays).UTC()
+			if !b.Meta.Committed && createdAt.Before(uncommittedTimeout) {
+				remove = true
+			} else if b.Meta.Committed && createdAt.Before(committedTimeout) {
+				remove = true
+			}
+		} else {
 			remove = true
 		}
 

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -412,6 +412,12 @@ func (m *batchManager) remove(batch *batch) error {
 	if err := m.rclient.Del(m.getChildKey(batch.Id)).Err(); err != nil {
 		return fmt.Errorf("remove: batch children (%s), %v", batch.Id, err)
 	}
+	if err := m.rclient.Del(m.getSuccessJobStateKey(batch.Id)).Err(); err != nil {
+		return fmt.Errorf("remove: could delete expire success_st: %v", err)
+	}
+	if err := m.rclient.Del(m.getCompleteJobStateKey(batch.Id)).Err(); err != nil {
+		return fmt.Errorf("updatedCommitted: could not deletecomplete_st: %v", err)
+	}
 	return nil
 }
 

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -502,7 +502,7 @@ func (m *batchManager) updateJobCallbackState(batch *batch, callbackType string,
 			return fmt.Errorf("updateJobCallbackState: could not set success_st: %v", err)
 		}
 		if state == CallbackJobSucceeded {
-			go func() {
+			func() {
 				m.mu.Lock()
 				defer m.mu.Unlock()
 				m.removeBatch(batch)
@@ -514,7 +514,7 @@ func (m *batchManager) updateJobCallbackState(batch *batch, callbackType string,
 			return fmt.Errorf("updateJobCallbackState: could not set completed_st: %v", err)
 		}
 		if _, areChildrenSucceeded := m.areChildrenFinished(batch); areChildrenSucceeded && batch.Meta.SuccessJob == "" && state == CallbackJobSucceeded {
-			go func() {
+			func() {
 				m.mu.Lock()
 				defer m.mu.Unlock()
 				m.removeBatch(batch)

--- a/batch/batch.go
+++ b/batch/batch.go
@@ -549,8 +549,8 @@ func (m *batchManager) handleBatchJobsCompleted(batch *batch, parentsVisited map
 			// parent has already been notified
 			continue
 		}
-		m.lockBatch(parent.Id)
 		parentsVisited[parent.Id] = true
+		m.lockBatch(parent.Id)
 		m.handleChildComplete(parent, batch, areChildrenFinished, areChildrenSucceeded, parentsVisited)
 		m.unlockBatch(parent.Id)
 	}

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -399,11 +399,20 @@ func TestRemoveStaleBatches(t *testing.T) {
 		_, err = batchSystem.batchManager.newBatch(uncommittedBatchId, uncommittedMeta)
 		assert.Nil(t, err)
 
+		batchSystem.batchManager.lockBatchIfExists(uncommittedBatchId)
+		go func() {
+			time.Sleep(1)
+			batchSystem.batchManager.unlockBatchIfExists(uncommittedBatchId)
+			batchSystem.batchManager.lockBatchIfExists(uncommittedBatchId)
+			time.Sleep(1)
+			batchSystem.batchManager.unlockBatchIfExists(uncommittedBatchId)
+		}()
 		batchSystem.batchManager.removeStaleBatches()
 
 		_, err = batchSystem.batchManager.getBatch(committedBatchId)
 		assert.EqualError(t, err, "getBatch: no batch found")
 
+		batchSystem.batchManager.lockBatchIfExists(uncommittedBatchId)
 		_, err = batchSystem.batchManager.getBatch(uncommittedBatchId)
 		assert.EqualError(t, err, "getBatch: no batch found")
 	})

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -428,7 +428,6 @@ func withServer(batchSystem *BatchSubsystem, enabled bool, runner func(cl *clien
 		panic(err)
 	}
 	defer stopper()
-	defer s.Stop(nil)
 
 	go cli.HandleSignals(s)
 
@@ -457,6 +456,8 @@ func withServer(batchSystem *BatchSubsystem, enabled bool, runner func(cl *clien
 	}
 
 	runner(cl)
+	close(s.Stopper())
+	s.Stop(nil)
 }
 
 func getClient() (*client.Client, error) {

--- a/batch/child.go
+++ b/batch/child.go
@@ -35,7 +35,7 @@ func (m *batchManager) addChild(batch *batch, childBatch *batch) error {
 		return fmt.Errorf("addChild: erorr adding parent batch (%s) to child (%s): %v", batch.Id, childBatch.Id, err)
 	}
 	if m.areBatchJobsCompleted(batch) {
-		m.handleBatchJobsCompleted(batch, map[string]bool{batch.Id: true})
+		m.handleBatchJobsCompleted(batch, map[string]bool{batch.Id: true, childBatch.Id: true})
 	}
 	return nil
 }

--- a/batch/child.go
+++ b/batch/child.go
@@ -121,6 +121,9 @@ func (m *batchManager) handleChildComplete(batch *batch, childBatch *batch, areC
 }
 
 func (m *batchManager) areChildrenFinished(b *batch) (bool, bool) {
+	if len(b.Children) != b.Meta.ChildCount && b.Meta.ChildCount != 0 {
+		return false, false
+	}
 	// iterate through children up to a certain depth
 	// check to see if any batch still has jobs being processed
 	currentDepth := 1

--- a/batch/commands.go
+++ b/batch/commands.go
@@ -76,8 +76,8 @@ func (b *BatchSubsystem) batchCommand(c *server.Connection, s *server.Server, cm
 	case "OPEN":
 		batchId := parts[1]
 
-		b.batchManager.lockBatch(batchId)
-		defer b.batchManager.unlockBatch(batchId)
+		b.batchManager.lockBatchIfExists(batchId)
+		defer b.batchManager.unlockBatchIfExists(batchId)
 		batch, err := b.batchManager.getBatch(batchId)
 		if err != nil {
 			_ = c.Error(cmd, fmt.Errorf("cannot get batch: %v", err))
@@ -104,8 +104,8 @@ func (b *BatchSubsystem) batchCommand(c *server.Connection, s *server.Server, cm
 			_ = c.Error(cmd, errors.New("bid is required"))
 			return
 		}
-		b.batchManager.lockBatch(batchId)
-		defer b.batchManager.unlockBatch(batchId)
+		b.batchManager.lockBatchIfExists(batchId)
+		defer b.batchManager.unlockBatchIfExists(batchId)
 		batch, err := b.batchManager.getBatch(batchId)
 		if err != nil {
 			_ = c.Error(cmd, fmt.Errorf("cannot get batch: %v", err))
@@ -131,8 +131,8 @@ func (b *BatchSubsystem) batchCommand(c *server.Connection, s *server.Server, cm
 			_ = c.Error(cmd, fmt.Errorf("child batch and parent batch cannot be the same value"))
 			return
 		}
-		b.batchManager.lockBatch(batchId)
-		defer b.batchManager.unlockBatch(batchId)
+		b.batchManager.lockBatchIfExists(batchId)
+		defer b.batchManager.unlockBatchIfExists(batchId)
 		batch, err := b.batchManager.getBatch(batchId)
 		if err != nil {
 			_ = c.Error(cmd, fmt.Errorf("cannot get batch: %v", err))
@@ -148,8 +148,8 @@ func (b *BatchSubsystem) batchCommand(c *server.Connection, s *server.Server, cm
 			opened = true
 		}
 
-		b.batchManager.lockBatch(childBatchId)
-		defer b.batchManager.unlockBatch(childBatchId)
+		b.batchManager.lockBatchIfExists(childBatchId)
+		defer b.batchManager.unlockBatchIfExists(childBatchId)
 		childBatch, err := b.batchManager.getBatch(childBatchId)
 		ok := true
 		if err != nil {
@@ -172,8 +172,8 @@ func (b *BatchSubsystem) batchCommand(c *server.Connection, s *server.Server, cm
 		return
 	case "STATUS":
 		batchId := parts[1]
-		b.batchManager.lockBatch(batchId)
-		defer b.batchManager.unlockBatch(batchId)
+		b.batchManager.lockBatchIfExists(batchId)
+		defer b.batchManager.unlockBatchIfExists(batchId)
 		batch, err := b.batchManager.getBatch(batchId)
 		if err != nil {
 			_ = c.Error(cmd, fmt.Errorf("cannot find batch: %v", err))

--- a/batch/middlware.go
+++ b/batch/middlware.go
@@ -13,8 +13,8 @@ func (b *BatchSubsystem) pushMiddleware(next func() error, ctx manager.Context) 
 		if err != nil {
 			return fmt.Errorf("pushMiddleware: unable to parse batch id %s", bid)
 		}
-		b.batchManager.lockBatch(batchId)
-		defer b.batchManager.unlockBatch(batchId)
+		b.batchManager.lockBatchIfExists(batchId)
+		defer b.batchManager.unlockBatchIfExists(batchId)
 		batch, err := b.batchManager.getBatch(batchId)
 		if err != nil {
 			return fmt.Errorf("pushMiddleware: unable to retrieve batch %s", bid)
@@ -39,8 +39,8 @@ func (b *BatchSubsystem) handleJobFinished(success bool) func(next func() error,
 					util.Warnf("unable to parse batch id %s", bid)
 					return next()
 				}
-				b.batchManager.lockBatch(batchId)
-				defer b.batchManager.unlockBatch(batchId)
+				b.batchManager.lockBatchIfExists(batchId)
+				defer b.batchManager.unlockBatchIfExists(batchId)
 				batch, err := b.batchManager.getBatch(batchId)
 				if err != nil {
 					util.Warnf("unable to retrieve batch %s: %v", bid, err)
@@ -68,8 +68,8 @@ func (b *BatchSubsystem) handleJobFinished(success bool) func(next func() error,
 			if err != nil {
 				return fmt.Errorf("handleJobFinished: unable to parse batch id %s", bid)
 			}
-			b.batchManager.lockBatch(batchId)
-			defer b.batchManager.unlockBatch(batchId)
+			b.batchManager.lockBatchIfExists(batchId)
+			defer b.batchManager.unlockBatchIfExists(batchId)
 			batch, err := b.batchManager.getBatch(batchId)
 			if err != nil {
 				util.Warnf("handleJobFinished: unable to retrieve batch %s", bid)

--- a/batch/stress_test.go
+++ b/batch/stress_test.go
@@ -78,6 +78,7 @@ func TestBatchStress(t *testing.T) {
 	batchQueue, err := s.Store().GetQueue("batch_load_complete")
 	assert.Nil(t, err)
 	assert.EqualValues(t, waitGroups*total, int(batchQueue.Size()))
+	close(s.Stopper())
 	s.Stop(nil)
 }
 

--- a/batch/subsystem.go
+++ b/batch/subsystem.go
@@ -40,7 +40,6 @@ func (b *BatchSubsystem) Start(s *server.Server) error {
 		mu:        sync.Mutex{},
 		rclient:   b.Server.Manager().Redis(),
 		Subsystem: b,
-		batchMu:   make(map[string]*sync.Mutex),
 	}
 	b.Fetcher = manager.BasicFetcher(s.Manager().Redis())
 	if err := b.batchManager.loadExistingBatches(); err != nil {

--- a/batch/subsystem.go
+++ b/batch/subsystem.go
@@ -49,7 +49,7 @@ func (b *BatchSubsystem) Start(s *server.Server) error {
 	server.CommandSet["BATCH"] = b.batchCommand
 	b.addMiddleware()
 
-	b.Server.AddTask(3600, &removeStaleBatches{b})
+	b.Server.AddTask(3600*24, &removeStaleBatches{b}) // once a day
 	util.Info("Loaded batching plugin")
 	return nil
 }

--- a/batch/subsystem.go
+++ b/batch/subsystem.go
@@ -37,9 +37,10 @@ func (b *BatchSubsystem) Start(s *server.Server) error {
 	b.Server = s
 	b.batchManager = &batchManager{
 		Batches:   make(map[string]*batch),
-		mu:        sync.RWMutex{},
+		mu:        sync.Mutex{},
 		rclient:   b.Server.Manager().Redis(),
 		Subsystem: b,
+		batchMu:   make(map[string]*sync.Mutex),
 	}
 	b.Fetcher = manager.BasicFetcher(s.Manager().Redis())
 	if err := b.batchManager.loadExistingBatches(); err != nil {


### PR DESCRIPTION
### Description

We've been seeing some issues when loading batches after a restart. The remove stale batches wasnt able to remove these batches. I believe there are some race conditions around updating batches which lead to a state where the batch is deleted but the failed / completed state attributes were being updated.

This PR modifies locking so we lock a batch before we attempt to retrieve it. We also properly set the expiration for other keys when updating committed. We also delete invalid batches when we reload them to reduce future error messages.

This PR makes a change so that jobs do not fail if ran after a batch has expired


### Testing

- [x] copied the production faktory redis db and ran it locally with no errors for when the task runs
- [x] modified the removeStaleBatches task to run every 5 seconds and delete batches that were over 5 seconds old
- [x] ran the BatchExample job within core multiple times with and without the above modification