### PR TITLE
allow no cron entries in cron plugin when enabled

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -138,7 +138,8 @@ func (c *CronSubsystem) getOptions(s *server.Server) (*Options, error) {
 
 	cronJobsValue, ok := s.Options.GlobalConfig["cron"]
 	if !ok {
-		return &options, fmt.Errorf("getOptions: no cron jobs provided")
+		options.CronJobs = cronJobs
+		return &options, nil
 	}
 
 	if cronJobsInterface, ok := cronJobsValue.([]map[string]interface{}); ok {


### PR DESCRIPTION
PR allows the cron plugin to be enabled without any cron jobs configured