### PR TITLE
[PLAT-72] - change queue latency metric to histogram

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -116,7 +116,7 @@ func (m *MetricsSubsystem) createStatsDClient() error {
 
 	// dogstatsd doesn't parse DD_TAGS so do it here
 	if value := os.Getenv("DD_TAGS"); value != "" {
-		for _, tag := range strings.Split(value, "") {
+		for _, tag := range strings.Split(value, " ") {
 			tags = append(tags, strings.TrimSpace(tag))
 		}
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -118,11 +118,11 @@ func TestMetrics(t *testing.T) {
 			mockDoer.EXPECT().Gauge("jobs.dead.count", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.count", float64(8), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.default.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Gauge("jobs.enqueued.default.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Timing("jobs.enqueued.default.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.count", float64(6), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Timing("jobs.enqueued.builds.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Timing("jobs.enqueued.tests.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 
 			// create 15 jobs
 			// default queue

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -10,7 +10,6 @@ import (
 func (m *MetricsSubsystem) addMiddleware() {
 	m.Server.Manager().AddMiddleware("ack", func(next func() error, ctx manager.Context) error {
 		tags := m.getTagsFromJob(ctx)
-
 		if ctx.Reservation() != nil {
 			if err := m.StatsDClient().Timing(m.PrefixMetricName("succeeded.time"), time.Duration(time.Now().Sub(ctx.Reservation().ReservedAt())), tags, 1); err != nil {
 				util.Warnf("unable to submit metric: %v", err)

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -24,76 +24,77 @@ func (m *metricsTask) Name() string {
 
 // Execute - runs the task to collect metrics
 func (m *metricsTask) Execute() error {
-	connectionCount := m.Subsystem.Server.Stats.Connections
-	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("connections.count"), float64(connectionCount), m.Subsystem.Options.Tags, 1); err != nil {
-		util.Warnf("unable to submit metric: %v", err)
-	}
-	
-	workingCount := m.Subsystem.Server.Store().Working().Size()
-	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("working.count"), float64(workingCount), m.Subsystem.Options.Tags, 1); err != nil {
-		util.Warnf("unable to submit metric: %v", err)
-	}
-
-	scheduledCount := m.Subsystem.Server.Store().Scheduled().Size()
-	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("scheduled.count"), float64(scheduledCount), m.Subsystem.Options.Tags, 1); err != nil {
-		util.Warnf("unable to submit metric: %v", err)
-	}
-
-	retriesCount := m.Subsystem.Server.Store().Retries().Size()
-	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("retries.count"), float64(retriesCount), m.Subsystem.Options.Tags, 1); err != nil {
-		util.Warnf("unable to submit metric: %v", err)
-	}
-
-	deadCount := m.Subsystem.Server.Store().Dead().Size()
-	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("dead.count"), float64(deadCount), m.Subsystem.Options.Tags, 1); err != nil {
-		util.Warnf("unable to submit metric: %v", err)
-	}
-
-	var totalEnqueued uint64 = 0
-
-	m.Subsystem.Server.Store().EachQueue(func(queue storage.Queue) {
-		count := queue.Size()
-		totalEnqueued += count
-		queueCountMetricName := m.Subsystem.PrefixMetricName(fmt.Sprintf("enqueued.%s.count", queue.Name()))
-		if err := m.Subsystem.StatsDClient().Gauge(queueCountMetricName, float64(count), m.Subsystem.Options.Tags, 1); err != nil {
+	go func() {
+		connectionCount := m.Subsystem.Server.Stats.Connections
+		if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("connections.count"), float64(connectionCount), m.Subsystem.Options.Tags, 1); err != nil {
 			util.Warnf("unable to submit metric: %v", err)
 		}
 
-		queueLatencyMetricName := m.Subsystem.PrefixMetricName(fmt.Sprintf("enqueued.%s.time", queue.Name()))
-		var timeElapsed int64 = 0
-		// This does an LRANGE on the queue
-		// start is the offset from the left of the queue
-		// count is not the number of items to fetch, but rather the offset to the last item to return
-		// Jobs are LPUSH'd into the queue and RPOP'd out, so to get the last job we want -1, -1
-		queue.Page(-1, 0, func(_ int, data []byte) error {
-			var job client.Job
-			if err := json.Unmarshal(data, &job); err != nil {
-				util.Warnf("metrics task unable to unmarshal job data: %v", err)
-				return nil
+		workingCount := m.Subsystem.Server.Store().Working().Size()
+		if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("working.count"), float64(workingCount), m.Subsystem.Options.Tags, 1); err != nil {
+			util.Warnf("unable to submit metric: %v", err)
+		}
+
+		scheduledCount := m.Subsystem.Server.Store().Scheduled().Size()
+		if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("scheduled.count"), float64(scheduledCount), m.Subsystem.Options.Tags, 1); err != nil {
+			util.Warnf("unable to submit metric: %v", err)
+		}
+
+		retriesCount := m.Subsystem.Server.Store().Retries().Size()
+		if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("retries.count"), float64(retriesCount), m.Subsystem.Options.Tags, 1); err != nil {
+			util.Warnf("unable to submit metric: %v", err)
+		}
+
+		deadCount := m.Subsystem.Server.Store().Dead().Size()
+		if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("dead.count"), float64(deadCount), m.Subsystem.Options.Tags, 1); err != nil {
+			util.Warnf("unable to submit metric: %v", err)
+		}
+
+		var totalEnqueued uint64 = 0
+
+		m.Subsystem.Server.Store().EachQueue(func(queue storage.Queue) {
+			count := queue.Size()
+			totalEnqueued += count
+			queueCountMetricName := m.Subsystem.PrefixMetricName(fmt.Sprintf("enqueued.%s.count", queue.Name()))
+			if err := m.Subsystem.StatsDClient().Gauge(queueCountMetricName, float64(count), m.Subsystem.Options.Tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
 			}
 
-			t, err := util.ParseTime(job.EnqueuedAt)
-			if err != nil {
-				util.Warnf("metrics task unable to parse EnqueuedAt: %v", err)
-				return nil
-			}
-			timeElapsed = time.Duration(time.Now().Sub(t)).Milliseconds()
+			queueLatencyMetricName := m.Subsystem.PrefixMetricName(fmt.Sprintf("enqueued.%s.time", queue.Name()))
+			var timeElapsed int64 = 0
+			// This does an LRANGE on the queue
+			// start is the offset from the left of the queue
+			// count is not the number of items to fetch, but rather the offset to the last item to return
+			// Jobs are LPUSH'd into the queue and RPOP'd out, so to get the last job we want -1, -1
+			queue.Page(-1, 0, func(_ int, data []byte) error {
+				var job client.Job
+				if err := json.Unmarshal(data, &job); err != nil {
+					util.Warnf("metrics task unable to unmarshal job data: %v", err)
+					return nil
+				}
 
-			return nil
+				t, err := util.ParseTime(job.EnqueuedAt)
+				if err != nil {
+					util.Warnf("metrics task unable to parse EnqueuedAt: %v", err)
+					return nil
+				}
+				timeElapsed = time.Duration(time.Now().Sub(t)).Milliseconds()
+
+				return nil
+			})
+			if err := m.Subsystem.StatsDClient().Gauge(queueLatencyMetricName, float64(timeElapsed), m.Subsystem.Options.Tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
+			}
+
+			util.Debugf("metrics: %s: %d", queueCountMetricName, count)
+			util.Debugf("metrics: %s: %d", queueLatencyMetricName, timeElapsed)
 		})
-		if err := m.Subsystem.StatsDClient().Gauge(queueLatencyMetricName, float64(timeElapsed), m.Subsystem.Options.Tags, 1); err != nil {
+
+		if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("enqueued.count"), float64(totalEnqueued), m.Subsystem.Options.Tags, 1); err != nil {
 			util.Warnf("unable to submit metric: %v", err)
 		}
-
-		util.Debugf("metrics: %s: %d", queueCountMetricName, count)
-		util.Debugf("metrics: %s: %d", queueLatencyMetricName, timeElapsed)
-	})
-
-	if err := m.Subsystem.StatsDClient().Gauge(m.Subsystem.PrefixMetricName("enqueued.count"), float64(totalEnqueued), m.Subsystem.Options.Tags, 1); err != nil {
-		util.Warnf("unable to submit metric: %v", err)
-	}
-	util.Debugf("metrics: enqueued.count: %d", totalEnqueued)
-
+		util.Debugf("metrics: enqueued.count: %d", totalEnqueued)
+	}()
 	return nil
 }
 

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -61,7 +61,7 @@ func (m *metricsTask) Execute() error {
 			}
 
 			queueLatencyMetricName := m.Subsystem.PrefixMetricName(fmt.Sprintf("enqueued.%s.time", queue.Name()))
-			var timeElapsed int64 = 0
+			var timeElapsed time.Duration = 0
 			// This does an LRANGE on the queue
 			// start is the offset from the left of the queue
 			// count is not the number of items to fetch, but rather the offset to the last item to return
@@ -78,11 +78,11 @@ func (m *metricsTask) Execute() error {
 					util.Warnf("metrics task unable to parse EnqueuedAt: %v", err)
 					return nil
 				}
-				timeElapsed = time.Duration(time.Now().Sub(t)).Milliseconds()
+				timeElapsed = time.Duration(time.Now().Sub(t))
 
 				return nil
 			})
-			if err := m.Subsystem.StatsDClient().Gauge(queueLatencyMetricName, float64(timeElapsed), m.Subsystem.Options.Tags, 1); err != nil {
+			if err := m.Subsystem.StatsDClient().Timing(queueLatencyMetricName, timeElapsed, m.Subsystem.Options.Tags, 1); err != nil {
 				util.Warnf("unable to submit metric: %v", err)
 			}
 


### PR DESCRIPTION
This PR changes the metric for queue latency from a gauge to timing (which is a histogram). 

I've also made a change to run the metrics task in a go-routine. We've done this the other tasks since faktory's internal task system runs all tasks in the same routine, we've encountered issues with blocking that thread in the past.

See: https://fossa.atlassian.net/browse/PLAT-72

## Testing plan

1. build the daemon: `CGO_ENABLED=0 go build ./cmd/faktory/daemon.go`
2. create this file located at `~/.faktory/conf.d/statsd.toml`
```
[metrics]
enabled = true
namespace = "metrics_test"
```
3. Run faktory: `DD_AGENT_HOST=datadog-statsd.core.fossa.team ./daemon`
4. Submit any job to faktory - using core or hubble
5. Wait a minute or two
6. Goto datadog and you should see a `metrics_test.default.enqueued.time` metric - it will have metrics for avg, p95, min, and max.