### PR TITLE
Upgrade BurntSushi/toml to avoid decoding bug

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/server"

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -107,7 +107,7 @@ func (c *CronSubsystem) createCron() {
 }
 
 func (c *CronSubsystem) addCronJobs() error {
-	for index, _ := range c.Options.CronJobs {
+	for index := range c.Options.CronJobs {
 		job := &c.Options.CronJobs[index]
 		id, err := c.Cron.AddJob(job.Schedule, &QueueJob{
 			Subsystem: c,

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -24,7 +24,7 @@ const (
 		args = [1, 3]
 		[cron.job.custom]
 		  testing = true
-		
+
     [[ cron ]]
 	  schedule = "* * * * * *" # every second
 	  [cron.job]
@@ -298,7 +298,14 @@ func TestCron(t *testing.T) {
 func runSystem(configDir string, runner func(s *server.Server)) {
 	dir := "/tmp/cron_system.db"
 	defer os.RemoveAll(dir)
-	opts := &cli.CliOptions{"localhost:7417", "localhost:7420", "development", configDir, "debug", dir}
+	opts := &cli.CliOptions{
+		CmdBinding:       "localhost:7417",
+		WebBinding:       "localhost:7420",
+		Environment:      "development",
+		ConfigDirectory:  configDir,
+		LogLevel:         "debug",
+		StorageDirectory: dir,
+	}
 	s, stopper, err := cli.BuildServer(opts)
 
 	defer s.Stop(nil)

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ require (
 	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/BurntSushi/toml v0.4.1 => github.com/BurntSushi/toml v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v0.4.1 // indirect
+	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/justinas/nosurf v1.1.1 // indirect
@@ -24,5 +24,3 @@ require (
 	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/BurntSushi/toml v0.4.1 => github.com/BurntSushi/toml v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
-github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDog/datadog-go v4.8.2+incompatible h1:qbcKSx29aBLD+5QLvlQZlGmRMF/FfGqFLFev/1TDzRo=
 github.com/DataDog/datadog-go v4.8.2+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=


### PR DESCRIPTION
There's a bug (see https://github.com/BurntSushi/toml/pull/339) in `BurnSushi/toml v0.4.1` that was causing empty arrays to be decoded into a nil interface.

If you print out the interface it looks correct:
```
map[args:[[]] custom:map[expires_in:5m] queue:default retry:0 type:analysisWatchdog]
```
But when you marshal it into JSON:
```
{"args":[null],"custom":{"expires_in":"5m"},"jobtype":"analysisWatchdog","queue":"default","retry":0,"type":"analysisWatchdog"}
```
Looking at the `interface` with [spew](https://github.com/davecgh/go-spew) it's clear that the inner array in `args` is nil:
```
(map[string]interface {}) (len=5) {
 (string) (len=4) "type": (string) (len=16) "analysisWatchdog",
 (string) (len=5) "queue": (string) (len=7) "default",
 (string) (len=5) "retry": (int64) 0,
 (string) (len=4) "args": ([]interface {}) (len=1 cap=1) {
  ([]interface {}) <nil>
 },
 (string) (len=6) "custom": (map[string]interface {}) (len=1) {
  (string) (len=10) "expires_in": (string) (len=2) "5m"
 }
}
```