### PR TITLE
Upgrade Faktory to 1.6.2 / Go 1.19

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/fossas/faktory-plugins
 
-go 1.18
+go 1.19
 
-require github.com/contribsys/faktory v1.6.1
+require github.com/contribsys/faktory v1.6.2
 
 require (
 	github.com/DataDog/datadog-go v4.8.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/DataDog/datadog-go v4.8.2+incompatible h1:qbcKSx29aBLD+5QLvlQZlGmRMF/
 github.com/DataDog/datadog-go v4.8.2+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/contribsys/faktory v1.6.1 h1:c+v9WSxkh1kpfmc5ZTuKifzkqMokWTWg8DvWlelXf5s=
-github.com/contribsys/faktory v1.6.1/go.mod h1:R8+inlM1rq3GzyG8iZUL7qhfNfXGIgcbQRvTHmSyuUI=
+github.com/contribsys/faktory v1.6.2 h1:HuqJI9ZEeInN2nJg10WRy8zPpxNwVIZgACbex7wQG1A=
+github.com/contribsys/faktory v1.6.2/go.mod h1:R8+inlM1rq3GzyG8iZUL7qhfNfXGIgcbQRvTHmSyuUI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Upstream [CHANGELOG](https://github.com/contribsys/faktory/blob/main/Changes.md#162) is low risk and includes a [fix](https://github.com/contribsys/faktory/issues/417) for an NPE we encountered when retrying a failed cronjob.