### PR TITLE
Bug fixes

### DIFF
--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -424,7 +424,6 @@ func withServer(batchSystem *BatchSubsystem, enabled bool, runner func(cl *clien
 	defer os.RemoveAll(dir)
 	opts := &cli.CliOptions{
 		CmdBinding:       "localhost:7416",
-		WebBinding:       "localhost:7420",
 		Environment:      "development",
 		ConfigDirectory:  ".",
 		LogLevel:         "debug",
@@ -458,10 +457,10 @@ func withServer(batchSystem *BatchSubsystem, enabled bool, runner func(cl *clien
 	}()
 
 	cl, err := getClient()
-	defer cl.Close()
 	if err != nil {
 		panic(err)
 	}
+	defer cl.Close()
 
 	runner(cl)
 	close(s.Stopper())

--- a/expire/expire.go
+++ b/expire/expire.go
@@ -66,6 +66,7 @@ func (e *ExpireSubsystem) parseExpiration(next func() error, ctx manager.Context
 			return fmt.Errorf("expire: Could not parse expires_in: %w", err)
 		}
 		ctx.Job().SetExpiresIn(duration)
+		delete(ctx.Job().Custom, "expires_in")
 	}
 
 	return next()

--- a/expire/expire_test.go
+++ b/expire/expire_test.go
@@ -1,6 +1,7 @@
 package expire
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -86,7 +87,7 @@ func TestRemovesExpiresIn(t *testing.T) {
 }
 
 func withServer(runner func(s *server.Server, cl *client.Client)) {
-	dir := "/tmp/requeue_test.db"
+	dir := fmt.Sprintf("/tmp/expire_test_%d.db", rand.Int())
 	defer os.RemoveAll(dir)
 
 	opts := &cli.CliOptions{

--- a/expire/expire_test.go
+++ b/expire/expire_test.go
@@ -1,0 +1,146 @@
+package expire
+
+import (
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/contribsys/faktory/cli"
+	"github.com/contribsys/faktory/client"
+	"github.com/contribsys/faktory/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpiresAt(t *testing.T) {
+	withServer(func(s *server.Server, cl *client.Client) {
+		// Push a job that has already expired
+		j1 := client.NewJob("JobOne", 1)
+		j1.SetExpiresAt(time.Now().Add(time.Minute * -1))
+		err := cl.Push(j1)
+		assert.Nil(t, err)
+
+		// Push a job that will expire
+		j2 := client.NewJob("JobOne", 1)
+		j2.SetExpiresAt(time.Now().Add(time.Minute * 1))
+		err = cl.Push(j2)
+		assert.Nil(t, err)
+
+		// The fetched job should be j2 because j1 is expired
+		job, err := cl.Fetch("default")
+		assert.Nil(t, err)
+		assert.Equal(t, j2.Jid, job.Jid)
+
+		// Verify that the queue is empty
+		job, err = cl.Fetch("default")
+		assert.Nil(t, err)
+		assert.Nil(t, job)
+	})
+}
+
+func TestExpiresIn(t *testing.T) {
+	withServer(func(s *server.Server, cl *client.Client) {
+		// Push a job that has already expired
+		j1 := client.NewJob("JobOne", 1)
+		j1.SetExpiresIn(time.Minute * -1)
+		err := cl.Push(j1)
+		assert.Nil(t, err)
+
+		// Push a job that will expire
+		j2 := client.NewJob("JobOne", 1)
+		j2.SetExpiresIn(time.Minute * 1)
+		err = cl.Push(j2)
+		assert.Nil(t, err)
+
+		// The fetched job should be j2 because j1 is expired
+		job, err := cl.Fetch("default")
+		assert.Nil(t, err)
+		assert.Equal(t, j2.Jid, job.Jid)
+
+		// Verify that the queue is empty
+		job, err = cl.Fetch("default")
+		assert.Nil(t, err)
+		assert.Nil(t, job)
+	})
+}
+
+// The `expires_in` value is converted to a timestamp and saved as `expires_at`
+func TestRemovesExpiresIn(t *testing.T) {
+	withServer(func(s *server.Server, cl *client.Client) {
+		// Push a job that has already expired
+		j1 := client.NewJob("JobOne", 1)
+		j1.SetCustom("expires_in", (time.Duration(1) * time.Minute).String())
+		err := cl.Push(j1)
+		assert.Nil(t, err)
+
+		// The fetched job should not have `expires_in` set
+		job, err := cl.Fetch("default")
+		assert.Nil(t, err)
+		assert.Equal(t, j1.Jid, job.Jid)
+		jobExpIn, _ := job.GetCustom("expires_in")
+		assert.Nil(t, jobExpIn)
+		jobExpAt, _ := job.GetCustom("expires_at")
+		assert.NotNil(t, jobExpAt)
+	})
+}
+
+func withServer(runner func(s *server.Server, cl *client.Client)) {
+	dir := "/tmp/requeue_test.db"
+	defer os.RemoveAll(dir)
+
+	opts := &cli.CliOptions{
+		CmdBinding:       "localhost:7414",
+		Environment:      "development",
+		ConfigDirectory:  ".",
+		LogLevel:         "debug",
+		StorageDirectory: dir,
+	}
+	s, stopper, err := cli.BuildServer(opts)
+	if err != nil {
+		panic(err)
+	}
+	defer stopper()
+
+	go cli.HandleSignals(s)
+
+	err = s.Boot()
+	if err != nil {
+		panic(err)
+	}
+	s.Register(new(ExpireSubsystem))
+
+	go func() {
+		err := s.Run()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	cl, err := getClient()
+	if err != nil {
+		panic(err)
+	}
+	defer cl.Close()
+
+	runner(s, cl)
+	close(s.Stopper())
+	s.Stop(nil)
+}
+
+func getClient() (*client.Client, error) {
+	// this is a worker process so we need to set the global WID before connecting
+	client.RandomProcessWid = strconv.FormatInt(rand.Int63(), 32)
+
+	srv := client.DefaultServer()
+	srv.Address = "localhost:7414"
+	cl, err := client.Dial(srv, "123456")
+	if err != nil {
+		return nil, err
+	}
+	if _, err = cl.Beat(); err != nil {
+		return nil, err
+	}
+
+	return cl, nil
+}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -248,7 +248,6 @@ func runSystem(configDir string, runner func(s *server.Server, cl *client.Client
 	defer os.RemoveAll(dir)
 	opts := &cli.CliOptions{
 		CmdBinding:       "localhost:7418",
-		WebBinding:       "localhost:7420",
 		Environment:      "development",
 		ConfigDirectory:  configDir,
 		LogLevel:         "debug",

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -244,7 +244,7 @@ func createJob(queue string, jobtype string, args ...interface{}) *client.Job {
 }
 
 func runSystem(configDir string, runner func(s *server.Server, cl *client.Client)) {
-	dir := "/tmp/batching_system.db"
+	dir := fmt.Sprintf("/tmp/metrics_test_%d.db", rand.Int())
 	defer os.RemoveAll(dir)
 	opts := &cli.CliOptions{
 		CmdBinding:       "localhost:7418",

--- a/requeue/requeue.go
+++ b/requeue/requeue.go
@@ -58,6 +58,12 @@ func (r *RequeueSubsystem) requeueCommand(c *server.Connection, s *server.Server
 		_ = c.Error(cmd, err)
 		return
 	}
+	// Acknowledge will not return a job (nor an error) if there's no in-memory
+	// reservation for the given jid.
+	if job == nil {
+		_ = c.Error(cmd, fmt.Errorf("requeue: Can't requeue job with no reservation"))
+		return
+	}
 
 	q, err := s.Store().GetQueue(job.Queue)
 	if err != nil {

--- a/requeue/requeue.go
+++ b/requeue/requeue.go
@@ -58,7 +58,7 @@ func (r *RequeueSubsystem) requeueCommand(c *server.Connection, s *server.Server
 		_ = c.Error(cmd, err)
 		return
 	}
-	// Acknowledge will not return a job (nor an error) if there's no in-memory
+	// s.Manager().Acknowledge() will return (nil, nil) if there's no in-memory
 	// reservation for the given jid.
 	if job == nil {
 		_ = c.Error(cmd, fmt.Errorf("requeue: Can't requeue job with no reservation"))

--- a/requeue/requeue_test.go
+++ b/requeue/requeue_test.go
@@ -98,7 +98,7 @@ func withServer(runner func(s *server.Server, cl *client.Client)) {
 	defer os.RemoveAll(dir)
 
 	opts := &cli.CliOptions{
-		CmdBinding:       "localhost:7414",
+		CmdBinding:       "localhost:7412",
 		Environment:      "development",
 		ConfigDirectory:  ".",
 		LogLevel:         "debug",
@@ -141,7 +141,7 @@ func getClient() (*client.Client, error) {
 	client.RandomProcessWid = strconv.FormatInt(rand.Int63(), 32)
 
 	srv := client.DefaultServer()
-	srv.Address = "localhost:7414"
+	srv.Address = "localhost:7412"
 	cl, err := client.Dial(srv, "123456")
 	if err != nil {
 		return nil, err

--- a/requeue/requeue_test.go
+++ b/requeue/requeue_test.go
@@ -94,7 +94,7 @@ func TestNoReservation(t *testing.T) {
 }
 
 func withServer(runner func(s *server.Server, cl *client.Client)) {
-	dir := "/tmp/requeue_test.db"
+	dir := fmt.Sprintf("/tmp/requeue_test_%d.db", rand.Int())
 	defer os.RemoveAll(dir)
 
 	opts := &cli.CliOptions{


### PR DESCRIPTION
### [Unset expires_in when queueing jobs](https://github.com/fossas/faktory-plugins/commit/6f5e1b324d5c8729fff6399992a8d81e461c7b53) 

The `expires_in` field is meant to be a duration after which the job will expire.
This value gets converted into a timestamp that is stored as `expires_at`.

Having both `expires_in` and `expires_at` set when queueing a job would be ambiguous,
and is therfore an error. Unfortunately we were not following the same rules when
parsing `expires_in` and jobs with that set were being queued with both fields. This
did not play well with the `requeue` plugin which requeues jobs exactly as they're
defined, and would then encounter the error about the ambiguity.

Unsetting `expires_in` after it has been converted to a timestamp should resolve
the issue.

### [Possible NPE when requeueing jobs](https://github.com/fossas/faktory-plugins/commit/c71550992d9d9822c0e2bba0754654f801c0b653) 

Faktory's `manager.Acknowledge` can return `(nil, nil)` if the given`jid` doesn't match an
in-memory reservation. The `requeue` implementation expected Faktory to return an error if
no job was found. The lack of an error resulted in an NPE when we tried to dereference the
`job`.

If no job is returned then requeueing is aborted.