### PR TITLE
Refactor metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ enabled = true # enables this plugin
 | faktory.jobs.retries                                 | Gauge     | Current number of jobs to be retried                                                                                                 |
 | faktory.jobs.dead                                    | Gauge     | Current number of dead jobs                                                                                                          |
 | faktory.jobs.enqueued{queue}                         | Gauge     | Number of jobs in {queue}                                                                                                            |
-| faktory.jobs.latency{queue}                          | Gauge     | The time between now and when the oldest queued job was enqueued                                                                     |
+| faktory.jobs.current_latency{queue}                  | Gauge     | The time between now and when the oldest queued job was enqueued                                                                     |
+| faktory.jobs.latency{queue}                          | Histogram | Timing for how long the oldest job has waited in the queue                                                                           |
 | faktory.jobs.pushed{queue, jobtype}                  | Counter   | Total number of jobs pushed                                                                                                          |
 | faktory.jobs.fetched{queue, jobtype}                 | Counter   | Total number of jobs fetched                                                                                                         |
 | faktory.jobs.processed{queue, jobtype, status, dead} | Histogram | Timing for jobs that have been ACKed or FAILed. `status` is one of `success` or `fail`. `dead` is a boolean present for failed jobs. |

--- a/README.md
+++ b/README.md
@@ -19,23 +19,18 @@ enabled = true # enables this plugin
 
 ### Dogstatsd Metrics
 
-Metrics are collected through a task and middleware.
-
-Metrics tracked through middleware are:
-`jobs.succeeded.time.count` - number of jobs successful
-`jobs.succeeded.time` - time to complete
-`jobs.failed.time.count` - number of jobs failed
-`jobs.failed.time` - time to complete
-
-Metrics tracked through a task (every 10 seconds) are:
-
-`jobs.enqueued.{queueName}.count` - number of jobs in a queue by name
-`jobs.enqueued.{queueName}.time` - current queue time for next job
-`jobs.working.count` - number of jobs currently running
-`jobs.scheduled.count` - number of jobs scheduled
-`jobs.retries.count` - number of jobs in retry state
-`jobs.dead.count` - number of dead jobs
-`jobs.enqueued.count` - total number of enqueued jobs
+| Name                                                 | Type      | Description                                                                                                                          |
+| ---------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| faktory.ops.connections                              | Gauge     | Faktory client network connections                                                                                                   |
+| faktory.jobs.working                                 | Gauge     | Current number of jobs being processed                                                                                               |
+| faktory.jobs.scheduled                               | Gauge     | Current number of scheduled jobs                                                                                                     |
+| faktory.jobs.retries                                 | Gauge     | Current number of jobs to be retried                                                                                                 |
+| faktory.jobs.dead                                    | Gauge     | Current number of dead jobs                                                                                                          |
+| faktory.jobs.enqueued{queue}                         | Gauge     | Number of jobs in {queue}                                                                                                            |
+| faktory.jobs.latency{queue}                          | Gauge     | The time between now and when the oldest queued job was enqueued                                                                     |
+| faktory.jobs.pushed{queue, jobtype}                  | Counter   | Total number of jobs pushed                                                                                                          |
+| faktory.jobs.fetched{queue, jobtype}                 | Counter   | Total number of jobs fetched                                                                                                         |
+| faktory.jobs.processed{queue, jobtype, status, dead} | Histogram | Timing for jobs that have been ACKed or FAILed. `status` is one of `success` or `fail`. `dead` is a boolean present for failed jobs. |
 
 #### Configuration (required)
 
@@ -44,7 +39,6 @@ Any file ending in .toml will be read as a configuration file for faktory. Here'
 ```
 [metrics]
 enabled = true # enables this plugin
-namespace = "jobs" # changes the prefix for the metric from `jobs.` to the value specified
 tags = ["tag1:value1", "tag2:value2"] # tags passed to datadog on every metric
 ```
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -132,6 +132,7 @@ func (m *MetricsSubsystem) createStatsDClient() error {
 func (m *MetricsSubsystem) getTagsFromJob(ctx manager.Context) []string {
 	jobType := fmt.Sprintf("jobtype:%s", ctx.Job().Type)
 	queueName := fmt.Sprintf("queue:%s", ctx.Job().Queue)
+
 	return []string{
 		jobType,
 		queueName,

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -110,24 +110,39 @@ func TestMetrics(t *testing.T) {
 			// middleware jobs
 			tags := []string{"tag1:value1", "tag2:value2"}
 			mockDoer.EXPECT().Timing("jobs.succeeded.time", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+			mockDoer.EXPECT().Timing("faktory.jobs.processed", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 			mockDoer.EXPECT().Timing("jobs.failed.time", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+			mockDoer.EXPECT().Timing("faktory.jobs.processed", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+			mockDoer.EXPECT().Incr("faktory.jobs.pushed", gomock.Any(), float64(1)).Return(nil).Times(15)
+			mockDoer.EXPECT().Incr("faktory.jobs.fetched", gomock.Any(), float64(1)).Return(nil).Times(6)
 
 			// task calls
 			mockDoer.EXPECT().Gauge("jobs.connections.count", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.ops.connections", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.working.count", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.working", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.scheduled.count", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.scheduled", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.retries.count", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.retries", float64(1), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.dead.count", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.dead", float64(0), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.count", float64(8), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.default.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(1), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.default.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.default.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.latency", gomock.Any(), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.count", float64(6), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(6), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.builds.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.latency", gomock.Any(), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(1), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.tests.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.latency", gomock.Any(), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 
 			// create 15 jobs
 			// default queue

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -132,17 +132,20 @@ func TestMetrics(t *testing.T) {
 			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(1), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.default.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.default.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Gauge("faktory.jobs.latency", gomock.Any(), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.current_latency", gomock.Any(), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Timing("faktory.jobs.latency", gomock.Any(), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.count", float64(6), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(6), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.builds.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Gauge("faktory.jobs.latency", gomock.Any(), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.current_latency", gomock.Any(), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Timing("faktory.jobs.latency", gomock.Any(), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(1), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.tests.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
-			mockDoer.EXPECT().Gauge("faktory.jobs.latency", gomock.Any(), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.jobs.current_latency", gomock.Any(), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Timing("faktory.jobs.latency", gomock.Any(), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 
 			// create 15 jobs
 			// default queue

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/contribsys/faktory/manager"
@@ -9,12 +10,38 @@ import (
 )
 
 func (m *MetricsSubsystem) addMiddleware() {
-	m.Server.Manager().AddMiddleware("ack", func(ctx context.Context, next func() error) error {
+	m.Server.Manager().AddMiddleware("push", func(ctx context.Context, next func() error) error {
 		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 		tags := m.getTagsFromJob(mh)
 
+		if err := m.StatsDClient().Incr("faktory.jobs.pushed", tags, float64(1)); err != nil {
+			util.Warnf("unable to submit metric: %v", err)
+		}
+
+		return next()
+	})
+
+	m.Server.Manager().AddMiddleware("fetch", func(ctx context.Context, next func() error) error {
+		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
+		tags := m.getTagsFromJob(mh)
+
+		if err := m.StatsDClient().Incr("faktory.jobs.fetched", tags, float64(1)); err != nil {
+			util.Warnf("unable to submit metric: %v", err)
+		}
+
+		return next()
+	})
+
+	m.Server.Manager().AddMiddleware("ack", func(ctx context.Context, next func() error) error {
+		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
+		tags := m.getTagsFromJob(mh)
+		tags = append(tags, "status:success")
+
 		if mh.Reservation() != nil {
 			if err := m.StatsDClient().Timing(m.PrefixMetricName("succeeded.time"), time.Duration(time.Since(mh.Reservation().ReservedAt())), tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
+			}
+			if err := m.StatsDClient().Timing("faktory.jobs.processed", time.Duration(time.Since(mh.Reservation().ReservedAt())), tags, 1); err != nil {
 				util.Warnf("unable to submit metric: %v", err)
 			}
 		}
@@ -25,9 +52,18 @@ func (m *MetricsSubsystem) addMiddleware() {
 	m.Server.Manager().AddMiddleware("fail", func(ctx context.Context, next func() error) error {
 		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 		tags := m.getTagsFromJob(mh)
+		// A job is dead and will not be retried if `Retry` is nil or 0, or if
+		// `RetryRemaining` is 0.
+		dead := (mh.Job().Retry == nil || *mh.Job().Retry == 0) || mh.Job().Failure.RetryRemaining == 0
+		tags = append(tags, "status:fail", fmt.Sprintf("dead:%t", dead))
 
 		if mh.Reservation() != nil {
-			m.StatsDClient().Timing(m.PrefixMetricName("failed.time"), time.Duration(time.Since(mh.Reservation().ReservedAt())), tags, 1)
+			if err := m.StatsDClient().Timing(m.PrefixMetricName("failed.time"), time.Duration(time.Since(mh.Reservation().ReservedAt())), tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
+			}
+			if err := m.StatsDClient().Timing("faktory.jobs.processed", time.Duration(time.Since(mh.Reservation().ReservedAt())), tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
+			}
 		}
 		return next()
 	})

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -110,7 +110,10 @@ func (m *metricsTask) Execute(ctx context.Context) error {
 			if err := m.Subsystem.StatsDClient().Timing(queueLatencyMetricNameHist, timeElapsed, m.Subsystem.Options.Tags, 1); err != nil {
 				util.Warnf("unable to submit metric: %v", err)
 			}
-			if err := m.Subsystem.StatsDClient().Gauge("faktory.jobs.latency", float64(timeElapsed.Milliseconds()), tags, 1); err != nil {
+			if err := m.Subsystem.StatsDClient().Gauge("faktory.jobs.current_latency", float64(timeElapsed.Milliseconds()), tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
+			}
+			if err := m.Subsystem.StatsDClient().Timing("faktory.jobs.latency", timeElapsed, tags, 1); err != nil {
 				util.Warnf("unable to submit metric: %v", err)
 			}
 


### PR DESCRIPTION
PLAT-189 PLAT-463 PLAT-482

Metrics have been refactored so that they are namespaced under `faktory.` rather than a configurable value. Per-queue metrics have been replaced with a single metric with a `queue` label.

The existing metrics have been maintained so that we can migrate our Datadog monitors and dashboards without downtime.

New metrics are:

| Name                                                 | Type      | Description                                                                                                                          |
| ---------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| faktory.ops.connections                              | Gauge     | Faktory client network connections                                                                                                   |
| faktory.jobs.working                                 | Gauge     | Current number of jobs being processed                                                                                               |
| faktory.jobs.scheduled                               | Gauge     | Current number of scheduled jobs                                                                                                     |
| faktory.jobs.retries                                 | Gauge     | Current number of jobs to be retried                                                                                                 |
| faktory.jobs.dead                                    | Gauge     | Current number of dead jobs                                                                                                          |
| faktory.jobs.enqueued{queue}                         | Gauge     | Number of jobs in {queue}                                                                                                            |
| faktory.jobs.latency{queue}                          | Gauge     | The time between now and when the oldest queued job was enqueued                                                                     |
| faktory.jobs.pushed{queue, jobtype}                  | Counter   | Total number of jobs pushed                                                                                                          |
| faktory.jobs.fetched{queue, jobtype}                 | Counter   | Total number of jobs fetched                                                                                                         |
| faktory.jobs.processed{queue, jobtype, status, dead} | Histogram | Timing for jobs that have been ACKed or FAILed. `status` is one of `success` or `fail`. `dead` is a boolean present for failed jobs. |