### PR TITLE
Use the context interface rather than struct

### DIFF
--- a/batch/middlware.go
+++ b/batch/middlware.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (b *BatchSubsystem) pushMiddleware(ctx context.Context, next func() error) error {
-	mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Ctx)
+	mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 
 	if bid, ok := mh.Job().GetCustom("bid"); ok {
 		batchId, err := b.batchManager.getBatchIdFromInterface(bid)
@@ -33,7 +33,7 @@ func (b *BatchSubsystem) pushMiddleware(ctx context.Context, next func() error) 
 
 func (b *BatchSubsystem) handleJobFinished(success bool) func(ctx context.Context, next func() error) error {
 	return func(ctx context.Context, next func() error) error {
-		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Ctx)
+		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 
 		if success {
 			// check if this is a success / complete job from batch

--- a/uniq/uniq.go
+++ b/uniq/uniq.go
@@ -73,7 +73,7 @@ func (u *UniqSubsystem) addMiddleware() {
 }
 
 func (u *UniqSubsystem) lockMiddleware(ctx context.Context, next func() error) error {
-	mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Ctx)
+	mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 
 	var uniqueFor float64
 	uniqueForValue, ok := mh.Job().GetCustom("unique_for")
@@ -129,7 +129,7 @@ func (u *UniqSubsystem) lockMiddleware(ctx context.Context, next func() error) e
 
 func (u *UniqSubsystem) releaseLockMiddleware(releaseAt string) func(context.Context, func() error) error {
 	return func(ctx context.Context, next func() error) error {
-		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Ctx)
+		mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 
 		if _, ok := mh.Job().GetCustom("unique_for"); !ok {
 			return next()


### PR DESCRIPTION
Fixes a bug where we were coercing values into a struct rather than the interface implemented by the struct. This caused a panic when the value would occasionally be a `requeue.Ctx`.