### PR TITLE
Fix batch plugin interaction with REQUEUE

### DIFF
--- a/batch/middleware.go
+++ b/batch/middleware.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/contribsys/faktory/manager"
 	"github.com/contribsys/faktory/util"
+	"github.com/fossas/faktory-plugins/requeue"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -26,6 +27,12 @@ var pushToMatchLua = redis.NewScript(`
 
 // pushMiddleware tracks jobs being added to a batch
 func (b *BatchSubsystem) pushMiddleware(ctx context.Context, next func() error) error {
+	// During REQUEUE, the job is being put back on the queue — not a new addition.
+	// Skip batch accounting so total/pending counters are not inflated.
+	if requeue.IsRequeue(ctx) {
+		return next()
+	}
+
 	mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 	job := mh.Job()
 
@@ -77,6 +84,12 @@ func (b *BatchSubsystem) pushMiddleware(ctx context.Context, next func() error) 
 
 // ackMiddleware handles job completion (success)
 func (b *BatchSubsystem) ackMiddleware(ctx context.Context, next func() error) error {
+	// During REQUEUE, the job is being put back on the queue — not completed.
+	// Skip batch accounting so pending is not decremented prematurely.
+	if requeue.IsRequeue(ctx) {
+		return next()
+	}
+
 	mh := ctx.Value(manager.MiddlewareHelperKey).(manager.Context)
 	job := mh.Job()
 

--- a/batch/middleware_test.go
+++ b/batch/middleware_test.go
@@ -563,9 +563,6 @@ func TestRequeueThenAckCompletesBatch(t *testing.T) {
 		err = cl.Ack(fetched2.Jid)
 		require.NoError(t, err)
 
-		// Allow time for the async callback check
-		time.Sleep(100 * time.Millisecond)
-
 		// Callback SHOULD fire now
 		callback, err := cl.Fetch("callbacks")
 		require.NoError(t, err)
@@ -628,8 +625,6 @@ func TestRequeueMultipleTimesCountersCorrect(t *testing.T) {
 		require.NotNil(t, fetched)
 		err = cl.Ack(fetched.Jid)
 		require.NoError(t, err)
-
-		time.Sleep(100 * time.Millisecond)
 
 		statusResult, err = cl.Generic("BATCH STATUS " + bid)
 		require.NoError(t, err)

--- a/batch/middleware_test.go
+++ b/batch/middleware_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/server"
+	"github.com/fossas/faktory-plugins/requeue"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -443,4 +444,199 @@ func TestFailMiddleware(t *testing.T) {
 			assert.Equal(t, int64(0), status.Failed, "failed should be 0 on non-first non-terminal failure")
 		})
 	})
+}
+
+func TestRequeueDoesNotAffectBatchCounters(t *testing.T) {
+	withServerConfig(true, func(s *server.Server, cl *client.Client) {
+		// Create batch with a complete callback
+		result, err := cl.Generic(`BATCH NEW {"complete":{"jobtype":"CompleteCallback","queue":"callbacks"}}`)
+		require.NoError(t, err)
+		bid := string(result)
+
+		// Push two jobs
+		job1 := client.NewJob("TestJob", 1)
+		job1.SetCustom("bid", bid)
+		err = cl.Push(job1)
+		require.NoError(t, err)
+
+		job2 := client.NewJob("TestJob", 2)
+		job2.SetCustom("bid", bid)
+		err = cl.Push(job2)
+		require.NoError(t, err)
+
+		// Commit batch
+		_, err = cl.Generic("BATCH COMMIT " + bid)
+		require.NoError(t, err)
+
+		// Fetch job1 and REQUEUE it
+		fetched, err := cl.Fetch("default")
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+		assert.Equal(t, job1.Jid, fetched.Jid)
+
+		_, err = cl.Generic(fmt.Sprintf(`REQUEUE {"jid":%q}`, fetched.Jid))
+		require.NoError(t, err)
+
+		// Check counters: REQUEUE should not change total or pending
+		statusResult, err := cl.Generic("BATCH STATUS " + bid)
+		require.NoError(t, err)
+
+		var status client.BatchStatus
+		err = json.Unmarshal([]byte(statusResult), &status)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(2), status.Total, "total should remain 2 after REQUEUE")
+		assert.Equal(t, int64(2), status.Pending, "pending should remain 2 after REQUEUE")
+		assert.Equal(t, int64(0), status.Failed, "failed should remain 0 after REQUEUE")
+	}, new(requeue.RequeueSubsystem))
+}
+
+func TestRequeueLastPendingJobDoesNotFireCallbacks(t *testing.T) {
+	withServerConfig(true, func(s *server.Server, cl *client.Client) {
+		// Create batch with a single job
+		result, err := cl.Generic(`BATCH NEW {"complete":{"jobtype":"CompleteCallback","queue":"callbacks"}}`)
+		require.NoError(t, err)
+		bid := string(result)
+
+		job := client.NewJob("TestJob", 1)
+		job.SetCustom("bid", bid)
+		err = cl.Push(job)
+		require.NoError(t, err)
+
+		_, err = cl.Generic("BATCH COMMIT " + bid)
+		require.NoError(t, err)
+
+		// Fetch and REQUEUE the only job
+		fetched, err := cl.Fetch("default")
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+
+		_, err = cl.Generic(fmt.Sprintf(`REQUEUE {"jid":%q}`, fetched.Jid))
+		require.NoError(t, err)
+
+		// Callback should NOT have fired
+		callback, err := cl.Fetch("callbacks")
+		require.NoError(t, err)
+		assert.Nil(t, callback, "complete callback should not fire after REQUEUE")
+
+		// pending should still be 1
+		statusResult, err := cl.Generic("BATCH STATUS " + bid)
+		require.NoError(t, err)
+
+		var status client.BatchStatus
+		err = json.Unmarshal([]byte(statusResult), &status)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), status.Pending, "pending should still be 1")
+	}, new(requeue.RequeueSubsystem))
+}
+
+func TestRequeueThenAckCompletesBatch(t *testing.T) {
+	withServerConfig(true, func(s *server.Server, cl *client.Client) {
+		// Create batch with a single job
+		result, err := cl.Generic(`BATCH NEW {"complete":{"jobtype":"CompleteCallback","queue":"callbacks"}}`)
+		require.NoError(t, err)
+		bid := string(result)
+
+		job := client.NewJob("TestJob", 1)
+		job.SetCustom("bid", bid)
+		err = cl.Push(job)
+		require.NoError(t, err)
+
+		_, err = cl.Generic("BATCH COMMIT " + bid)
+		require.NoError(t, err)
+
+		// Fetch and REQUEUE
+		fetched, err := cl.Fetch("default")
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+
+		_, err = cl.Generic(fmt.Sprintf(`REQUEUE {"jid":%q}`, fetched.Jid))
+		require.NoError(t, err)
+
+		// Fetch the requeued job and ACK it
+		fetched2, err := cl.Fetch("default")
+		require.NoError(t, err)
+		require.NotNil(t, fetched2)
+		assert.Equal(t, job.Jid, fetched2.Jid)
+
+		err = cl.Ack(fetched2.Jid)
+		require.NoError(t, err)
+
+		// Allow time for the async callback check
+		time.Sleep(100 * time.Millisecond)
+
+		// Callback SHOULD fire now
+		callback, err := cl.Fetch("callbacks")
+		require.NoError(t, err)
+		require.NotNil(t, callback, "complete callback should fire after REQUEUE then ACK")
+		assert.Equal(t, "CompleteCallback", callback.Type)
+
+		// Counters should be correct
+		statusResult, err := cl.Generic("BATCH STATUS " + bid)
+		require.NoError(t, err)
+
+		var status client.BatchStatus
+		err = json.Unmarshal([]byte(statusResult), &status)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), status.Total, "total should be 1")
+		assert.Equal(t, int64(0), status.Pending, "pending should be 0 after ACK")
+		assert.Equal(t, int64(0), status.Failed, "failed should be 0")
+	}, new(requeue.RequeueSubsystem))
+}
+
+func TestRequeueMultipleTimesCountersCorrect(t *testing.T) {
+	withServerConfig(true, func(s *server.Server, cl *client.Client) {
+		// Create batch
+		result, err := cl.Generic(`BATCH NEW {"complete":{"jobtype":"CompleteCallback","queue":"callbacks"}}`)
+		require.NoError(t, err)
+		bid := string(result)
+
+		job := client.NewJob("TestJob", 1)
+		job.SetCustom("bid", bid)
+		err = cl.Push(job)
+		require.NoError(t, err)
+
+		_, err = cl.Generic("BATCH COMMIT " + bid)
+		require.NoError(t, err)
+
+		// REQUEUE 3 times
+		for i := 0; i < 3; i++ {
+			fetched, err := cl.Fetch("default")
+			require.NoError(t, err)
+			require.NotNil(t, fetched)
+
+			_, err = cl.Generic(fmt.Sprintf(`REQUEUE {"jid":%q}`, fetched.Jid))
+			require.NoError(t, err)
+		}
+
+		// Counters should be unchanged after 3 requeues
+		statusResult, err := cl.Generic("BATCH STATUS " + bid)
+		require.NoError(t, err)
+
+		var status client.BatchStatus
+		err = json.Unmarshal([]byte(statusResult), &status)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), status.Total, "total should still be 1 after 3 requeues")
+		assert.Equal(t, int64(1), status.Pending, "pending should still be 1 after 3 requeues")
+
+		// Now ACK it
+		fetched, err := cl.Fetch("default")
+		require.NoError(t, err)
+		require.NotNil(t, fetched)
+		err = cl.Ack(fetched.Jid)
+		require.NoError(t, err)
+
+		time.Sleep(100 * time.Millisecond)
+
+		statusResult, err = cl.Generic("BATCH STATUS " + bid)
+		require.NoError(t, err)
+		err = json.Unmarshal([]byte(statusResult), &status)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), status.Total, "total should be 1 after final ACK")
+		assert.Equal(t, int64(0), status.Pending, "pending should be 0 after final ACK")
+	}, new(requeue.RequeueSubsystem))
 }

--- a/batch/test_helper_test.go
+++ b/batch/test_helper_test.go
@@ -18,8 +18,9 @@ func withServer(runner func(s *server.Server, cl *client.Client)) {
 	withServerConfig(true, runner)
 }
 
-// withServerConfig creates a test server with configurable batch subsystem state
-func withServerConfig(batchEnabled bool, runner func(s *server.Server, cl *client.Client)) {
+// withServerConfig creates a test server with configurable batch subsystem state.
+// Additional subsystems can be registered via the variadic parameter.
+func withServerConfig(batchEnabled bool, runner func(s *server.Server, cl *client.Client), subsystems ...server.Subsystem) {
 	dir := fmt.Sprintf("/tmp/batch_test_%d.db", rand.Int())
 	defer os.RemoveAll(dir)
 
@@ -57,6 +58,9 @@ enabled = %t
 		panic(err)
 	}
 	s.Register(new(BatchSubsystem))
+	for _, sub := range subsystems {
+		s.Register(sub)
+	}
 
 	go func() {
 		err := s.Run()

--- a/requeue/context.go
+++ b/requeue/context.go
@@ -1,9 +1,23 @@
 package requeue
 
 import (
+	"context"
+
 	"github.com/contribsys/faktory/client"
 	"github.com/contribsys/faktory/manager"
 )
+
+type contextKey string
+
+// RequeueContextKey is set on the context during a REQUEUE operation.
+// Other middleware (e.g. batch) can check for this to skip accounting
+// that should not apply when a job is being requeued rather than completed.
+const RequeueContextKey contextKey = "requeue"
+
+// IsRequeue returns true if the context indicates a REQUEUE operation is in progress.
+func IsRequeue(ctx context.Context) bool {
+	return ctx.Value(RequeueContextKey) != nil
+}
 
 var _ manager.Context = &Ctx{}
 

--- a/requeue/requeue.go
+++ b/requeue/requeue.go
@@ -52,7 +52,8 @@ func (r *RequeueSubsystem) requeueCommand(c *server.Connection, s *server.Server
 		_ = c.Error(cmd, fmt.Errorf("invalid REQUEUE %s", data))
 		return
 	}
-	job, err := s.Manager().Acknowledge(c.Context, jid)
+	requeueCtx := context.WithValue(c.Context, RequeueContextKey, true)
+	job, err := s.Manager().Acknowledge(requeueCtx, jid)
 	if err != nil {
 		_ = c.Error(cmd, err)
 		return
@@ -64,7 +65,7 @@ func (r *RequeueSubsystem) requeueCommand(c *server.Connection, s *server.Server
 		return
 	}
 
-	q, err := s.Store().GetQueue(c.Context, job.Queue)
+	q, err := s.Store().GetQueue(requeueCtx, job.Queue)
 	if err != nil {
 		_ = c.Error(cmd, err)
 		return
@@ -76,7 +77,7 @@ func (r *RequeueSubsystem) requeueCommand(c *server.Connection, s *server.Server
 	// https://github.com/contribsys/faktory/blob/v1.8.0/manager/manager.go#L222-L236
 	// https://github.com/contribsys/faktory/blob/v1.8.0/manager/manager.go#L251-L255
 	// https://github.com/contribsys/faktory/blob/v1.8.0/storage/queue_redis.go#L104
-	ctxh := context.WithValue(c.Context, manager.MiddlewareHelperKey, Ctx{job, s.Manager(), nil})
+	ctxh := context.WithValue(requeueCtx, manager.MiddlewareHelperKey, Ctx{job, s.Manager(), nil})
 	err = callMiddleware(ctxh, pushChain, func() error {
 		job.EnqueuedAt = util.Nows()
 		jdata, err := json.Marshal(job)


### PR DESCRIPTION
## Summary

The REQUEUE command (`REQUEUE {"jid":"..."}`) has two bugs when used on a job that belongs to a batch:

### Bug 1: Race condition causing premature callback firing and job loss

REQUEUE works by calling `Acknowledge()` (which fires the ACK middleware) then re-pushing the job (which fires the PUSH middleware). Between these two steps, the batch plugin's `ackMiddleware` decrements `pending` — potentially to 0 — and spawns a goroutine to check callbacks. If that goroutine runs before the PUSH middleware re-increments `pending`, it sees `pending=0` and fires the complete callback. The subsequent PUSH then fails with "cannot add jobs to batch after callbacks have started" because the Lua script checks callback state. The job is now **lost**: it was ACK'd out of the working set but never re-enqueued.

### Bug 2: Inflated `total` counter

Even without the race, each REQUEUE increments `total` via the push middleware while the ACK middleware decrements `pending`. The PUSH middleware then increments both `total` and `pending` back. Net effect: `total` grows by 1 per REQUEUE. A 2-job batch where one job is requeued 3 times shows `total=5`.

### Root cause

Both bugs stem from the same issue: the batch plugin's ACK and PUSH middleware treat REQUEUE as a completion followed by a new job addition, when semantically REQUEUE means "put the job back, it's still pending."

### Fix

The requeue plugin now sets a context flag (`RequeueContextKey`) before calling `Acknowledge()` and the push middleware chain. The batch plugin's `ackMiddleware` and `pushMiddleware` check for this flag and skip all batch accounting when it's set. During REQUEUE, batch counters (`total`, `pending`, `failed`) are completely untouched — the job remains "pending" from the batch's perspective.

## Test plan

- [x] `TestRequeueDoesNotAffectBatchCounters` — REQUEUE a batch job, verify total/pending/failed unchanged
- [x] `TestRequeueLastPendingJobDoesNotFireCallbacks` — REQUEUE the last pending job, verify callbacks don't fire
- [x] `TestRequeueThenAckCompletesBatch` — REQUEUE then ACK, verify batch completes correctly
- [x] `TestRequeueMultipleTimesCountersCorrect` — REQUEUE 3 times then ACK, verify counters are correct
- [x] All existing batch and requeue tests pass