### PR TITLE
Add faktory.queue.paused gauge to metrics plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ enabled = true # enables this plugin
 | Name                                                 | Type      | Description                                                                                                                          |
 | ---------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | faktory.ops.connections                              | Gauge     | Faktory client network connections                                                                                                   |
+| faktory.queue.paused{queue}                          | Gauge     | 1 if {queue} is paused, 0 otherwise                                                                                                  |
 | faktory.jobs.working                                 | Gauge     | Current number of jobs being processed                                                                                               |
 | faktory.jobs.scheduled                               | Gauge     | Current number of scheduled jobs                                                                                                     |
 | faktory.jobs.retries                                 | Gauge     | Current number of jobs to be retried                                                                                                 |

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -244,10 +244,17 @@ func TestMetrics(t *testing.T) {
 
 			tags := []string{"tag1:value1", "tag2:value2"}
 
-			// Specific expectation registered first so gomock matches it before the
-			// catch-all below. If Execute fails to emit queue_paused=1 for the paused
-			// queue, this expectation goes unsatisfied and pausedCtrl.Finish() fails.
-			mockDoer.EXPECT().Gauge("faktory.queue.paused", float64(1), append(tags, "queue:paused_q"), gomock.Any()).Return(nil).Times(1)
+			// Execute emits metrics from a goroutine, so we need to wait for the
+			// paused gauge to fire before pausedCtrl.Finish() validates expectations.
+			// DoAndReturn closes pausedEmitted when the specific call is matched.
+			pausedEmitted := make(chan struct{})
+			mockDoer.EXPECT().
+				Gauge("faktory.queue.paused", float64(1), append(tags, "queue:paused_q"), gomock.Any()).
+				DoAndReturn(func(_ string, _ float64, _ []string, _ float64) error {
+					close(pausedEmitted)
+					return nil
+				}).
+				Times(1)
 
 			// Catch-alls absorb the other middleware and task emissions; this subtest
 			// only asserts the new paused-state metric.
@@ -268,9 +275,11 @@ func TestMetrics(t *testing.T) {
 
 			m := &metricsTask{system}
 			m.Execute(ctx)
-			// Execute runs work in a goroutine; wait for it to finish before
-			// the deferred pausedCtrl.Finish() validates expectations.
-			time.Sleep(500 * time.Millisecond)
+			select {
+			case <-pausedEmitted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for faktory.queue.paused emission")
+			}
 		})
 	})
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -134,18 +134,21 @@ func TestMetrics(t *testing.T) {
 			mockDoer.EXPECT().Timing("jobs.enqueued.default.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.current_latency", gomock.Any(), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("faktory.jobs.latency", gomock.Any(), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.queue.paused", float64(0), append(tags, "queue:default"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.count", float64(6), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(6), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.builds.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.builds.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.current_latency", gomock.Any(), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("faktory.jobs.latency", gomock.Any(), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.queue.paused", float64(0), append(tags, "queue:builds"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.count", float64(1), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.enqueued", float64(1), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("jobs.enqueued.tests.time", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("jobs.enqueued.tests.time_hist", gomock.Any(), tags, gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Gauge("faktory.jobs.current_latency", gomock.Any(), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 			mockDoer.EXPECT().Timing("faktory.jobs.latency", gomock.Any(), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
+			mockDoer.EXPECT().Gauge("faktory.queue.paused", float64(0), append(tags, "queue:tests"), gomock.Any()).Return(nil).Times(1)
 
 			// create 15 jobs
 			// default queue
@@ -218,6 +221,56 @@ func TestMetrics(t *testing.T) {
 
 			m := &metricsTask{system}
 			m.Execute(ctx)
+		})
+	})
+
+	t.Run("paused queue is reported as 1", func(t *testing.T) {
+		pausedCtrl := gomock.NewController(t)
+		defer pausedCtrl.Finish()
+		mockDoer := mocks.NewMockClientInterface(pausedCtrl)
+
+		system := new(MetricsSubsystem)
+		ctx := context.Background()
+		configDir := createConfigDir(t)
+		confgFile := fmt.Sprintf("%s/conf.d/statsd.toml", configDir)
+		if err := ioutil.WriteFile(confgFile, []byte(statsdConfig), os.FileMode(0444)); err != nil {
+			panic(err)
+		}
+		runSystem(configDir, func(server *server.Server, cl *client.Client) {
+			system.Server = server
+			system.Options = system.getOptions(server)
+			system.statsDClient = mockDoer
+			system.addMiddleware()
+
+			tags := []string{"tag1:value1", "tag2:value2"}
+
+			// Specific expectation registered first so gomock matches it before the
+			// catch-all below. If Execute fails to emit queue_paused=1 for the paused
+			// queue, this expectation goes unsatisfied and pausedCtrl.Finish() fails.
+			mockDoer.EXPECT().Gauge("faktory.queue.paused", float64(1), append(tags, "queue:paused_q"), gomock.Any()).Return(nil).Times(1)
+
+			// Catch-alls absorb the other middleware and task emissions; this subtest
+			// only asserts the new paused-state metric.
+			mockDoer.EXPECT().Gauge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockDoer.EXPECT().Timing(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockDoer.EXPECT().Incr(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			if err := cl.Push(createJob("paused_q", "Test", 1)); err != nil {
+				panic(err)
+			}
+			q, ok := server.Store().ExistingQueue(ctx, "paused_q")
+			if !ok {
+				t.Fatal("queue paused_q not found after push")
+			}
+			if err := q.Pause(ctx); err != nil {
+				t.Fatalf("unable to pause queue: %v", err)
+			}
+
+			m := &metricsTask{system}
+			m.Execute(ctx)
+			// Execute runs work in a goroutine; wait for it to finish before
+			// the deferred pausedCtrl.Finish() validates expectations.
+			time.Sleep(500 * time.Millisecond)
 		})
 	})
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -244,14 +244,21 @@ func TestMetrics(t *testing.T) {
 
 			tags := []string{"tag1:value1", "tag2:value2"}
 
-			// Execute emits metrics from a goroutine, so we need to wait for the
-			// paused gauge to fire before pausedCtrl.Finish() validates expectations.
-			// DoAndReturn closes pausedEmitted when the specific call is matched.
-			pausedEmitted := make(chan struct{})
+			// Assert the paused queue is reported as 1.
 			mockDoer.EXPECT().
 				Gauge("faktory.queue.paused", float64(1), append(tags, "queue:paused_q"), gomock.Any()).
+				Return(nil).
+				Times(1)
+
+			// Execute emits metrics from a goroutine. To avoid racing the goroutine
+			// against pausedCtrl.Finish(), wait for the final unconditional emission
+			// in Execute — the namespaced "jobs.enqueued.count" gauge — before
+			// returning from the runner.
+			executeDone := make(chan struct{})
+			mockDoer.EXPECT().
+				Gauge("jobs.enqueued.count", gomock.Any(), gomock.Any(), gomock.Any()).
 				DoAndReturn(func(_ string, _ float64, _ []string, _ float64) error {
-					close(pausedEmitted)
+					close(executeDone)
 					return nil
 				}).
 				Times(1)
@@ -276,9 +283,9 @@ func TestMetrics(t *testing.T) {
 			m := &metricsTask{system}
 			m.Execute(ctx)
 			select {
-			case <-pausedEmitted:
+			case <-executeDone:
 			case <-time.After(5 * time.Second):
-				t.Fatal("timed out waiting for faktory.queue.paused emission")
+				t.Fatal("timed out waiting for metrics task to finish")
 			}
 		})
 	})

--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -38,6 +38,9 @@ func (m *MetricsSubsystem) addMiddleware() {
 		tags = append(tags, "status:success")
 
 		if mh.Reservation() != nil {
+			// Deprecated: namespaced "<namespace>.*" metrics (PrefixMetricName) are
+			// retained for backward compatibility only. New metrics in this plugin
+			// should be emitted exclusively via the faktory.* tagged form.
 			if err := m.StatsDClient().Timing(m.PrefixMetricName("succeeded.time"), time.Duration(time.Since(mh.Reservation().ReservedAt())), tags, 1); err != nil {
 				util.Warnf("unable to submit metric: %v", err)
 			}

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -24,6 +24,10 @@ func (m *metricsTask) Name() string {
 }
 
 // Execute - runs the task to collect metrics
+//
+// Note: The namespaced "<namespace>.*" metric emissions in this file (built via
+// PrefixMetricName) are deprecated. New metrics should be emitted only in the
+// canonical faktory.* tagged form.
 func (m *metricsTask) Execute(ctx context.Context) error {
 	go func() {
 		connectionCount := m.Subsystem.Server.Stats.Connections
@@ -68,8 +72,25 @@ func (m *metricsTask) Execute(ctx context.Context) error {
 
 		var totalEnqueued uint64 = 0
 
+		pausedQueues, err := m.Subsystem.Server.Store().PausedQueues(ctx)
+		if err != nil {
+			util.Warnf("unable to fetch paused queues: %v", err)
+		}
+		pausedSet := make(map[string]struct{}, len(pausedQueues))
+		for _, name := range pausedQueues {
+			pausedSet[name] = struct{}{}
+		}
+
 		m.Subsystem.Server.Store().EachQueue(ctx, func(queue storage.Queue) {
 			tags := append(m.Subsystem.Options.Tags, fmt.Sprintf("queue:%s", queue.Name()))
+
+			var pausedValue float64
+			if _, ok := pausedSet[queue.Name()]; ok {
+				pausedValue = 1
+			}
+			if err := m.Subsystem.StatsDClient().Gauge("faktory.queue.paused", pausedValue, tags, 1); err != nil {
+				util.Warnf("unable to submit metric: %v", err)
+			}
 
 			count := queue.Size(ctx)
 			totalEnqueued += count

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -74,7 +74,7 @@ func (m *metricsTask) Execute(ctx context.Context) error {
 
 		pausedQueues, err := m.Subsystem.Server.Store().PausedQueues(ctx)
 		pausedLookupFailed := err != nil
-		if err != nil {
+		if pausedLookupFailed {
 			util.Warnf("unable to fetch paused queues: %v", err)
 		}
 		pausedSet := make(map[string]struct{}, len(pausedQueues))
@@ -85,8 +85,7 @@ func (m *metricsTask) Execute(ctx context.Context) error {
 		m.Subsystem.Server.Store().EachQueue(ctx, func(queue storage.Queue) {
 			tags := append(m.Subsystem.Options.Tags, fmt.Sprintf("queue:%s", queue.Name()))
 
-			// Skip emission on lookup failure — emitting 0 here would falsely report
-			// every queue as active when we don't actually know.
+			// Skip emission on lookup failure
 			if !pausedLookupFailed {
 				var pausedValue float64
 				if _, ok := pausedSet[queue.Name()]; ok {

--- a/metrics/task.go
+++ b/metrics/task.go
@@ -73,6 +73,7 @@ func (m *metricsTask) Execute(ctx context.Context) error {
 		var totalEnqueued uint64 = 0
 
 		pausedQueues, err := m.Subsystem.Server.Store().PausedQueues(ctx)
+		pausedLookupFailed := err != nil
 		if err != nil {
 			util.Warnf("unable to fetch paused queues: %v", err)
 		}
@@ -84,12 +85,16 @@ func (m *metricsTask) Execute(ctx context.Context) error {
 		m.Subsystem.Server.Store().EachQueue(ctx, func(queue storage.Queue) {
 			tags := append(m.Subsystem.Options.Tags, fmt.Sprintf("queue:%s", queue.Name()))
 
-			var pausedValue float64
-			if _, ok := pausedSet[queue.Name()]; ok {
-				pausedValue = 1
-			}
-			if err := m.Subsystem.StatsDClient().Gauge("faktory.queue.paused", pausedValue, tags, 1); err != nil {
-				util.Warnf("unable to submit metric: %v", err)
+			// Skip emission on lookup failure — emitting 0 here would falsely report
+			// every queue as active when we don't actually know.
+			if !pausedLookupFailed {
+				var pausedValue float64
+				if _, ok := pausedSet[queue.Name()]; ok {
+					pausedValue = 1
+				}
+				if err := m.Subsystem.StatsDClient().Gauge("faktory.queue.paused", pausedValue, tags, 1); err != nil {
+					util.Warnf("unable to submit metric: %v", err)
+				}
 			}
 
 			count := queue.Size(ctx)


### PR DESCRIPTION
## Summary
- Emits a per-queue `faktory.queue.paused` gauge (1 if the queue is paused, 0 otherwise) on the existing 30s metrics task tick. Dashboards and alerts can now distinguish "queue has no work" from "queue is paused and won't drain."
- Pause state is read once per tick via `store.PausedQueues(ctx)` and checked in-memory inside the existing `EachQueue` loop — one Redis round trip per tick regardless of queue count.
- Marks the legacy namespaced `<namespace>.*` metrics in `metrics/task.go` and `metrics/middleware.go` as deprecated. They are retained for backward compatibility; new metrics should be added only in the canonical `faktory.*` tagged form.
- README updated with a row for the new metric.

## Test plan
- [x] `go build ./metrics/...` clean
- [x] `go vet ./metrics/...` clean
- [x] `go test -count=1 ./metrics/...` passes (existing happy-path subtest extended with `faktory.queue.paused=0` expectations for each queue; new "paused queue is reported as 1" subtest pushes a job, calls `Pause(ctx)`, and asserts the gauge fires with value 1)
- [ ] Optional manual check against a local Faktory: push a job to `q1`, `PAUSE q1`, and confirm `faktory.queue.paused:1|g|#queue:q1,...` appears within 30s; `RESUME q1` flips it back to 0